### PR TITLE
fix: compile error "future created by async block is not `Send.."

### DIFF
--- a/src/query/storages/cache/src/object.rs
+++ b/src/query/storages/cache/src/object.rs
@@ -45,11 +45,11 @@ impl CachedObject for Vec<u8> {
 /// 2. create the CachedObjectAccessor with the cache provider
 /// 3. operation with object
 pub struct CachedObjectAccessor<T> {
-    cache: Arc<dyn ObjectCacheProvider<T>>,
+    cache: Arc<dyn ObjectCacheProvider<T> + Send + Sync>,
 }
 
 impl<T> CachedObjectAccessor<T> {
-    pub fn create(cache: Arc<dyn ObjectCacheProvider<T>>) -> CachedObjectAccessor<T> {
+    pub fn create(cache: Arc<dyn ObjectCacheProvider<T> + Send + Sync>) -> CachedObjectAccessor<T> {
         Self { cache }
     }
 

--- a/src/query/storages/fuse/src/pruning/pruning_executor.rs
+++ b/src/query/storages/fuse/src/pruning/pruning_executor.rs
@@ -39,7 +39,6 @@ use tracing::warn;
 use tracing::Instrument;
 
 use super::pruner;
-use crate::io::MetaReaders;
 use crate::io::SegmentReader;
 use crate::metrics::*;
 use crate::pruning::pruner::Pruner;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/policies/cla/

## Summary

fix compile error "future created by async block is not `Send..".


Fixes #issue

